### PR TITLE
Integrated dev server with Webpack 2

### DIFF
--- a/dev.server.js
+++ b/dev.server.js
@@ -8,7 +8,7 @@ const argv = require('yargs').argv
 const port = argv.port || 8080;
 
 let webpackConfig = require('./webpack.config.js');
-webpackConfig.entry.unshift(`webpack-dev-server/client?http://localhost:${port}/`);
+webpackConfig.entry['webpack_hm_client'] = `webpack-dev-server/client?http://localhost:${port}/`;
 const compiler = webpack(webpackConfig);
 
 var server = new WebpackDevServer(compiler, {


### PR DESCRIPTION
Fixed breaking change introduced by the upgrade to Webpack 2. The fix is addressing the following runtime error in dev.server.js below.

D:\dev\node\search-ui-seed\dev.server.js:11
webpackConfig.entry.unshift(`webpack-dev-server/client?http://localhost:${port}/`);

TypeError: webpackConfig.entry.unshift is not a function
    at Object.<anonymous> (D:\dev\node\search-ui-seed\dev.server.js:11:21)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3